### PR TITLE
libstagefright: revert stride alignment for software codecs on exynos4

### DIFF
--- a/media/libstagefright/colorconversion/SoftwareRenderer.cpp
+++ b/media/libstagefright/colorconversion/SoftwareRenderer.cpp
@@ -221,7 +221,7 @@ void SoftwareRenderer::render(
         CHECK_EQ(0, mapper.lock(
             buf->handle, GRALLOC_USAGE_SW_WRITE_OFTEN | GRALLOC_USAGE_YUV_ADDR, bounds, pYUVBuf));
 
-        size_t dst_c_stride = ALIGN(buf->stride / 2, 16);
+        size_t dst_c_stride = buf->stride / 2;
         uint8_t *dst_y = (uint8_t *)pYUVBuf[0];
         uint8_t *dst_v = (uint8_t *)pYUVBuf[1];
         uint8_t *dst_u = (uint8_t *)pYUVBuf[2];


### PR DESCRIPTION
YV12 alignment is fixed in the gralloc and it is no longer
required to align the stride here since the extra alignment
breaks software codecs.

https://github.com/NamelessRom/android_hardware_samsung/commit/f59d4fffb7647e53959a957a2bead902c72fe4ea

Change-Id: I6d635a196a761784bb8a01ff8a9df89cdc70a893
